### PR TITLE
archive command

### DIFF
--- a/provisioning/pgmaster/postgresql.conf
+++ b/provisioning/pgmaster/postgresql.conf
@@ -689,3 +689,6 @@ default_text_search_config = 'pg_catalog.english'
 #------------------------------------------------------------------------------
 
 # Add settings for extensions here
+
+archive_mode = on
+archive_command = 'rsync -a %p barman@192.168.11.22:/var/lib/barman/pgmaster/incoming/%f'

--- a/provisioning/playbook.yml
+++ b/provisioning/playbook.yml
@@ -163,4 +163,9 @@
     copy: src=barman/pgmaster.conf dest=/etc/barman.d/
     
   - name: create replica slot
-    command: barman receive-wal --create-slot pgmaster
+    command: {{ item }} 
+    with_items:
+      - "barman receive-wal --create-slot pgmaster"
+      - "/usr/bin/barman backup pgmaster || echo 0"
+      - "barman switch-xlog --force --archive pgmaster"
+    ignore_errors: yes


### PR DESCRIPTION
в выводе "barman check pgmaster" на хосте "barman" есть ошибки по "archive command",  эта строка из файла "postgresql.conf" на мастере PostreSQL, в данном коммите я добавил их и перечитал конфиг, также я закоментирован слейв сервер, он был не нужен для работы бекапа, и пакет pythona из установок, barman ставиться из epel-release-репозитория.