### PR TITLE
Var2

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -12,10 +12,10 @@ Vagrant.configure(2) do |config|
     pgmaster.vm.hostname = "pgmaster"
   end
 
-  config.vm.define "pgslave" do |pgslave|
-    pgslave.vm.network "private_network", ip: "192.168.11.21", virtualbox__intnet: false
-    pgslave.vm.hostname = "pgslave"
-  end
+#  config.vm.define "pgslave" do |pgslave|
+#    pgslave.vm.network "private_network", ip: "192.168.11.21", virtualbox__intnet: false
+#    pgslave.vm.hostname = "pgslave"
+#  end
 
   config.vm.define "barman" do |barman|
     barman.vm.network "private_network", ip: "192.168.11.22", virtualbox__intnet: false

--- a/provisioning/barman/pgmaster.conf
+++ b/provisioning/barman/pgmaster.conf
@@ -1,14 +1,14 @@
 [pgmaster]
 description =  "Master backup"
 
-conninfo = host=pgmaster port=5432 user=barman dbname=postgres
+conninfo = host=pgmaster port=5432 user=postgres
 backup_method = postgres
 
-streaming_conninfo = host=pgmaster port=5432 user=streaming_barman dbname=postgres
+streaming_conninfo = host=pgmaster port=5432 user=streaming_barman
 streaming_archiver = on
 slot_name = barman
 
-archiver = on
+#archiver = on
 streaming_archiver_name = barman_receive_wal
 retention_policy = RECOVERY WINDOW OF 7 DAYS
 minimum_redundancy = 5

--- a/provisioning/pgmaster/pg_hba.conf
+++ b/provisioning/pgmaster/pg_hba.conf
@@ -7,6 +7,7 @@ local   all             all                                     peer
 # IPv4 local connections:
 host    all             all             127.0.0.1/32            ident
 host    all             barman          192.168.11.22/32        md5
+host    all             postgres          192.168.11.22/32        trust
 host    all             postgres          192.168.11.21/32        trust
 # IPv6 local connections:
 host    all             all             ::1/128                 ident

--- a/provisioning/pgmaster/postgresql.conf
+++ b/provisioning/pgmaster/postgresql.conf
@@ -218,9 +218,9 @@ min_wal_size = 80MB
 
 # - Archiving -
 
-#archive_mode = on		# enables archiving; off, on, or always
+archive_mode = on		# enables archiving; off, on, or always
 				# (change requires restart)
-#archive_command = 'barman-wal-archive backup pgmaster %p'		# command to use to archive a logfile segment
+archive_command = 'barman-wal-archive backup pgmaster %p'		# command to use to archive a logfile segment
 				# placeholders: %p = path of file to archive
 				#               %f = file name only
 				# e.g. 'test ! -f /mnt/server/archivedir/%f && cp %p /mnt/server/archivedir/%f'

--- a/provisioning/playbook.yml
+++ b/provisioning/playbook.yml
@@ -33,7 +33,7 @@
         - vim
         - mc
         - tcpdump
-        - python-psycopg2
+          # - python-psycopg2
       state: latest
 
 - hosts: pgmaster

--- a/provisioning/playbook.yml
+++ b/provisioning/playbook.yml
@@ -163,4 +163,9 @@
     copy: src=barman/pgmaster.conf dest=/etc/barman.d/
     
   - name: create replica slot
-    command: barman receive-wal --create-slot pgmaster
+    command: "{{ item }}"
+    with_items:
+      - "barman receive-wal --create-slot pgmaster"
+      - "/usr/bin/barman backup pgmaster || echo 0"
+      - "barman switch-xlog --force --archive pgmaster"
+    ignore_errors: yes


### PR DESCRIPTION
Еще не знаю насколько это правильно понимаю работу barman через слоты, но результатом таких измений на стенде является интерактивная работа команда `barman backup pgmaster`, то есть занимается сессия, можно пустить в background `barman backup pgmaster &`, основным результатом является измнение объема каталога `var/lib/barman/pgmaster` на сервере barman что свидетельствует о деятельности бекапа.
Сначала кратко опишу изменения, далее тестирование 

#### Измения от master ветки
1.убираю  slave 
2. изменяю pgmaster.conf для barman, так как пользователь barman не настроен для прохода на pgmaster по id_rsa
3. добавляю пользователя postgres в pg_hba.conf от сервера 192.168.11.22
4. убираю пакет python, вызывает ошибку
5. дописываю playbook, своего рода преднастройка

#### Тестирование: 
\# После деплоя бекап может не запуститься, если в плейбуке не отработает последняя команда для хоста barman, необходимо ее выполнить
barman switch-xlog --force --archive pgmaster
\# Запускаем бекап на barman
barman backup pgmaster
\# Переходим на pgmaster
vagrant ssh pgmaster
\# Качаем демобазу
yum install wget -y && wget https://edu.postgrespro.ru/demo-big.zip
\# распаковываем
yum install unzip && unzip demo-big.zip
\# Заливаем дамп в БД, в это время переходим на сервер barman
su postgres -c "psql -p5432 -d postgres -f demo-big-20170815.sql"

\# второй сессией заходим на хост barman
\# мониторим каталог, основной объем валится в wall
watch 'echo -e  "$(du -h  /var/lib/barman/pgmaster/|tail -5)\n"'
